### PR TITLE
CI: remove osx from integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,6 @@ matrix :
           env :
               - PY_MAJOR_MINOR="3.8"
               - INSTALL_FILE="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-        - os : osx
-          env :
-              - PY_MAJOR_MINOR="3.6"
-              - INSTALL_FILE="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-        - os : osx
-          env :
-              - PY_MAJOR_MINOR="3.7"
-              - INSTALL_FILE="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-        - os : osx
-          env :
-              - PY_MAJOR_MINOR="3.8"
-              - INSTALL_FILE="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
 addons:
   apt:


### PR DESCRIPTION
Having a hard time getting pytorch to install properly on the osx
images from travis -- hopefully temporary.